### PR TITLE
green test: creates a timer from a serialized timer keeping paused state

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -36,9 +36,14 @@ class Timer {
       ? currentStartTimestamp
       : startTs;
 
+    const isStarted = startTimestamp >= 0;
+    const isRunning = currentStartTimestamp !== undefined;
+    const wasPausedAtLeastOneTime = pauseCount > 0;
+    const isPaused = isStarted && !isRunning && wasPausedAtLeastOneTime;
+
     this._label = label || '';
     this._startTimestamp = startTs;
-    this._currentStartTimestamp = currentTs;
+    this._currentStartTimestamp = !isPaused ? currentTs : undefined;
     this._endTimestamp = endTs;
     this._pauseCount = pauseCount || 0;
     this._accumulatedMs = accumulatedMs || 0;

--- a/test/timer.test.js
+++ b/test/timer.test.js
@@ -233,6 +233,21 @@ describe('Timer tests', () => {
       const newTimer = Timer.deserialize(timer.serialize());
       expect(newTimer.serialize()).to.deep.equal(timer.serialize());
     });
+
+    it('creates a timer from a serialized timer keeping paused state', async () => {
+      const newTimer = new Timer(({ label: 'paused-timer-test' }));
+      newTimer.start();
+      await sleep(100);
+      newTimer.pause();
+
+      const timerFromState = Timer.deserialize(newTimer.serialize()); 
+
+      expect(timerFromState.serialize()).to.deep.equal(newTimer.serialize());
+    });
+    
+    function sleep(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
   });
 
   describe('Timer.benchmark(fn)', () => {


### PR DESCRIPTION
I finally found a way to solve the bug without break the timer behavior. 
https://github.com/eyas-ranjous/timer-node/issues/26